### PR TITLE
fix(translations): add translations/en.json so entity names resolve correctly

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,16 @@ This is a Home Assistant custom integration, NOT a standard Python package.
 - `pytest-asyncio` with `asyncio_mode = "auto"`
 - Aim for 90%+ coverage; don't do excessive work to cover edge cases that provide little value
 
+### Live HA Testing (hot-deploy without releasing)
+
+If the user provides a live HA instance accessible via SSH running this integration, you may debug it directly.
+
+Workflow:
+1. `docker ps` to identify the HA container name and `docker inspect <container>` to find the config volume mount path
+2. `sudo cp` changed files into `<config_volume>/custom_components/jackery/` (create subdirs as needed)
+3. `docker restart <container>` to apply changes
+4. Verify in the HA UI — no HACS release needed
+
 ## Git Commits
 
 - Use conventional commits: `type(scope): description`

--- a/custom_components/jackery/translations/en.json
+++ b/custom_components/jackery/translations/en.json
@@ -1,0 +1,77 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Jackery Account",
+        "description": "Enter your Jackery app credentials.",
+        "data": {
+          "email": "Email",
+          "password": "Password"
+        }
+      }
+    },
+    "error": {
+      "invalid_auth": "Invalid email or password.",
+      "cannot_connect": "Unable to connect to Jackery servers.",
+      "no_devices": "No devices found on this account.",
+      "unknown": "An unexpected error occurred."
+    },
+    "abort": {
+      "already_configured": "This account is already configured."
+    }
+  },
+  "entity": {
+    "sensor": {
+      "battery": { "name": "Battery" },
+      "battery_temperature": { "name": "Battery temperature" },
+      "battery_state": {
+        "name": "Battery state",
+        "state": {
+          "idle": "Idle",
+          "charging": "Charging",
+          "discharging": "Discharging"
+        }
+      },
+      "input_power": { "name": "Input power" },
+      "output_power": { "name": "Output power" },
+      "time_to_full": { "name": "Time to full" },
+      "time_remaining": { "name": "Time remaining" },
+      "ac_input_power": { "name": "AC input power" },
+      "car_input_power": { "name": "Car input power" },
+      "ac_voltage": { "name": "AC voltage" },
+      "ac_frequency": { "name": "AC frequency" },
+      "ac_power": { "name": "AC power" },
+      "ac_power_secondary": { "name": "AC power (secondary)" },
+      "ac_socket_power": { "name": "AC socket power" },
+      "error_code": { "name": "Error code" },
+      "power_mode_battery": { "name": "Power mode battery" },
+      "total_temperature": { "name": "Total temperature" },
+      "system_status": { "name": "System status" }
+    },
+    "binary_sensor": {
+      "wireless_charging": { "name": "Wireless charging" },
+      "temperature_alarm": { "name": "Temperature alarm" },
+      "power_alarm": { "name": "Power alarm" }
+    },
+    "switch": {
+      "ac_output": { "name": "AC output" },
+      "dc_output": { "name": "DC output" },
+      "usb_output": { "name": "USB output" },
+      "car_output": { "name": "Car output" },
+      "ac_input": { "name": "AC input" },
+      "dc_input": { "name": "DC input" },
+      "super_fast_charge": { "name": "Super fast charge" },
+      "ups_mode": { "name": "UPS mode" }
+    },
+    "select": {
+      "light_mode": { "name": "Light mode" },
+      "charge_speed": { "name": "Charge speed" },
+      "battery_protection": { "name": "Battery protection" }
+    },
+    "number": {
+      "auto_shutdown": { "name": "Auto shutdown" },
+      "energy_saving": { "name": "Energy saving" },
+      "screen_timeout": { "name": "Screen timeout" }
+    }
+  }
+}


### PR DESCRIPTION
strings.json with an entity section is a dev-time template; HA runtime
loads translations/<lang>.json for entity name resolution. Without it,
entities fall back to device class labels or the device name.

Resolves: #3
