### PR TITLE
fix(sensor): pass through raw duration values instead of converting t…

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ Copy the `custom_components/jackery/` directory into your Home Assistant `custom
 | Battery state | enum | — | idle / charging / discharging |
 | Input power | power | W | |
 | Output power | power | W | |
-| Time to full | duration | h | Scaled ÷10, unknown when 0 |
-| Time remaining | duration | h | Scaled ÷10, unknown when 0 |
+| Time to full | duration | h | Scaled ÷10 |
+| Time remaining | duration | h | Scaled ÷10 |
 | AC input power | power | W | |
 | Car input power | power | W | |
 | AC voltage | voltage | V | Scaled ÷10 |

--- a/custom_components/jackery/sensor.py
+++ b/custom_components/jackery/sensor.py
@@ -52,12 +52,10 @@ def _battery_state_fn(raw: object) -> str | None:
 
 
 def _duration_fn(raw: object) -> float | None:
-    """Return None when raw duration is zero or the sentinel max value (999)."""
+    """Convert raw duration integer to hours (divide by 10)."""
     try:
         val = int(raw)  # type: ignore[call-overload]
     except (TypeError, ValueError):
-        return None
-    if val == 0 or val >= 999:
         return None
     return float(val) / 10
 

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -18,8 +18,8 @@ def test_manifest_required_fields():
     assert manifest["config_flow"] is True
     assert manifest["integration_type"] == "hub"
     assert manifest["iot_class"] == "cloud_push"
-    assert "socketry>=0.2.2" in manifest["requirements"]
-    assert manifest["version"] == "0.1.0"
+    assert "socketry>=0.2.3" in manifest["requirements"]
+    assert manifest["version"] == "0.2.1"
     assert "@jlopez" in manifest["codeowners"]
 
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -191,6 +191,13 @@ def test_time_remaining_zero():
     assert sensor.native_value == 0.0
 
 
+def test_time_to_full_999_returns_value():
+    """999 is passed through as a numeric value (99.9 hours)."""
+    coordinator = _make_coordinator(data={"SN001": {"it": 999}})
+    sensor = _make_sensor("it", coordinator=coordinator)
+    assert sensor.native_value == 99.9
+
+
 # --- AC sensors ---
 
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -173,10 +173,10 @@ def test_time_to_full_nonzero():
     assert sensor.native_value == 3.5
 
 
-def test_time_to_full_zero_returns_none():
+def test_time_to_full_zero():
     coordinator = _make_coordinator(data={"SN001": {"it": 0}})
     sensor = _make_sensor("it", coordinator=coordinator)
-    assert sensor.native_value is None
+    assert sensor.native_value == 0.0
 
 
 def test_time_remaining_nonzero():
@@ -185,10 +185,10 @@ def test_time_remaining_nonzero():
     assert sensor.native_value == 12.0
 
 
-def test_time_remaining_zero_returns_none():
+def test_time_remaining_zero():
     coordinator = _make_coordinator(data={"SN001": {"ot": 0}})
     sensor = _make_sensor("ot", coordinator=coordinator)
-    assert sensor.native_value is None
+    assert sensor.native_value == 0.0
 
 
 # --- AC sensors ---


### PR DESCRIPTION
…o unknown

The _duration_fn was returning None for zero and >=999 raw values, causing HA to show "Unknown" for time_remaining and time_to_full sensors. These are valid readings that should be reported as-is.