### PR TITLE
feat: QR code device sharing via options flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,12 @@ htmlcov/
 # Environment
 .env
 
+# Home Assistant development
+ha-config/
+!ha-config/configuration.yaml
+!ha-config/secrets.yaml
+.HA_VERSION
+
 # Keep these
 !.env.example
 !.gitignore

--- a/README.md
+++ b/README.md
@@ -35,7 +35,21 @@ Copy the `custom_components/jackery/` directory into your Home Assistant `custom
 1. Go to **Settings → Devices & Services → Add Integration**
 2. Search for **Jackery Power Stations**
 3. Enter your Jackery app email and password
-4. The integration will discover all devices on your account
+
+### Dedicated Account (Recommended)
+
+Jackery only allows one device to be logged in to an account at a time — a new login will log out the previous device. Because of this, it is recommended that you create a separate Jackery account dedicated to Home Assistant, so the integration doesn't interfere with your mobile app.
+
+To share your devices with the new account:
+
+1. Create a new Jackery account (e.g. using a different email)
+2. Add the integration in Home Assistant using the new account credentials
+3. On the Jackery integration entry, click the gear icon (**Configure**)
+4. A QR code will be displayed
+5. In the Jackery mobile app on your **main** account, select the device you want to share, open its settings, and tap **Scan to share device(s)** to scan the QR code
+6. Click **Submit** in Home Assistant to reload the integration and pick up the newly shared devices
+
+If your account already has devices (e.g. you're using your main account), they'll be discovered automatically and setup completes immediately.
 
 ## Entities
 

--- a/custom_components/jackery/config_flow.py
+++ b/custom_components/jackery/config_flow.py
@@ -2,15 +2,19 @@
 
 from __future__ import annotations
 
+import json
 import logging
 from typing import Any
 
 import aiohttp
 import voluptuous as vol
-from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
-from socketry import AuthenticationError, Client
+from homeassistant.config_entries import ConfigFlow, ConfigFlowResult, OptionsFlow
+from homeassistant.core import callback
+from homeassistant.helpers.selector import QrCodeSelector
+from socketry import AuthenticationError, Client, SocketryError
 
 from .const import CONF_EMAIL, CONF_PASSWORD, DOMAIN
+from .coordinator import JackeryCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -33,8 +37,6 @@ class JackeryConfigFlow(ConfigFlow, domain=DOMAIN):  # type: ignore[call-arg,mis
 
             try:
                 client = await Client.login(email, password)
-                # login() fetches devices internally; read from the cached list.
-                devices = client.devices
             except AuthenticationError:
                 errors["base"] = "invalid_auth"
             except (aiohttp.ClientError, TimeoutError, OSError):
@@ -43,26 +45,29 @@ class JackeryConfigFlow(ConfigFlow, domain=DOMAIN):  # type: ignore[call-arg,mis
                 _LOGGER.exception("Unexpected error during Jackery login")
                 errors["base"] = "unknown"
             else:
-                if not devices:
-                    errors["base"] = "no_devices"
-                else:
-                    user_id = client.user_id
-                    await self.async_set_unique_id(user_id)
-                    self._abort_if_unique_id_configured()
+                user_id = client.user_id
+                await self.async_set_unique_id(user_id)
+                self._abort_if_unique_id_configured()
 
-                    return self.async_create_entry(
-                        title=email,
-                        data={
-                            CONF_EMAIL: email,
-                            CONF_PASSWORD: password,
-                        },
-                    )
+                return self.async_create_entry(
+                    title=email,
+                    data={
+                        CONF_EMAIL: email,
+                        CONF_PASSWORD: password,
+                    },
+                )
 
         return self.async_show_form(
             step_id="user",
             data_schema=self._build_schema(user_input),
             errors=errors,
         )
+
+    @staticmethod
+    @callback  # type: ignore[untyped-decorator]
+    def async_get_options_flow(config_entry: object) -> OptionsFlow:
+        """Create the options flow."""
+        return JackeryOptionsFlow()
 
     async def async_step_reauth(
         self,
@@ -117,4 +122,59 @@ class JackeryConfigFlow(ConfigFlow, domain=DOMAIN):  # type: ignore[call-arg,mis
                 ): str,
                 vol.Required(CONF_PASSWORD): str,
             }
+        )
+
+
+class JackeryOptionsFlow(OptionsFlow):  # type: ignore[misc]
+    """Jackery config options flow."""
+
+    async def async_step_init(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
+        """Handle options flow — generate and display a device-sharing QR code."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            # Reload the integration to pick up newly shared devices.
+            await self.hass.config_entries.async_reload(self.config_entry.entry_id)
+            return self.async_create_entry(title="", data={})
+
+        # Get the coordinator from the config entry
+        coordinator: JackeryCoordinator = self.config_entry.runtime_data
+        client = coordinator.client
+
+        if client is None:
+            errors["base"] = "cannot_connect"
+            return self.async_show_form(
+                step_id="init",
+                data_schema=vol.Schema({}),
+                errors=errors,
+            )
+
+        # Generate QR code
+        try:
+            qr_data = await client.generate_share_qrcode()  # type: ignore[attr-defined]
+        except (aiohttp.ClientError, TimeoutError, OSError):
+            errors["base"] = "cannot_connect"
+            return self.async_show_form(
+                step_id="init",
+                data_schema=vol.Schema({}),
+                errors=errors,
+            )
+        except SocketryError:
+            _LOGGER.exception("Failed to generate share QR code")
+            errors["base"] = "qr_failed"
+            return self.async_show_form(
+                step_id="init",
+                data_schema=vol.Schema({}),
+                errors=errors,
+            )
+
+        qr_json = json.dumps(qr_data, separators=(",", ":"))
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(
+                {
+                    vol.Optional("qr_code"): QrCodeSelector({"data": qr_json}),
+                }
+            ),
+            errors=errors,
         )

--- a/custom_components/jackery/config_flow.py
+++ b/custom_components/jackery/config_flow.py
@@ -10,6 +10,7 @@ import aiohttp
 import voluptuous as vol
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult, OptionsFlow
 from homeassistant.core import callback
+from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.selector import QrCodeSelector
 from socketry import AuthenticationError, Client, SocketryError
 
@@ -151,7 +152,7 @@ class JackeryOptionsFlow(OptionsFlow):  # type: ignore[misc]
 
         # Generate QR code
         try:
-            qr_data = await client.generate_share_qrcode()  # type: ignore[attr-defined]
+            qr_data = await client.generate_share_qrcode()
         except (aiohttp.ClientError, TimeoutError, OSError):
             errors["base"] = "cannot_connect"
             return self.async_show_form(
@@ -159,6 +160,8 @@ class JackeryOptionsFlow(OptionsFlow):  # type: ignore[misc]
                 data_schema=vol.Schema({}),
                 errors=errors,
             )
+        except AuthenticationError:
+            raise ConfigEntryAuthFailed from None
         except SocketryError:
             _LOGGER.exception("Failed to generate share QR code")
             errors["base"] = "qr_failed"

--- a/custom_components/jackery/manifest.json
+++ b/custom_components/jackery/manifest.json
@@ -10,7 +10,7 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/jlopez/jackery-ha/issues",
   "requirements": [
-    "socketry>=0.2.3"
+    "socketry>=0.2.4"
   ],
   "version": "0.2.1"
 }

--- a/custom_components/jackery/strings.json
+++ b/custom_components/jackery/strings.json
@@ -21,12 +21,27 @@
     "error": {
       "invalid_auth": "Invalid email or password.",
       "cannot_connect": "Unable to connect to Jackery servers.",
-      "no_devices": "No devices found on this account.",
       "unknown": "An unexpected error occurred."
     },
     "abort": {
       "already_configured": "This account is already configured.",
       "reauth_successful": "Re-authentication successful."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Share Jackery Devices",
+        "description": "In the Jackery mobile app, select the device you want to share, open its settings, and tap \"Scan to share device(s)\" to scan the QR code below. The QR code expires in 5 minutes. After scanning, submit this form to reload the integration and pick up the newly shared devices.",
+        "data": {
+          "qr_code": "Scan with Jackery Mobile App"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "Unable to connect to Jackery servers.",
+      "qr_failed": "Failed to generate sharing QR code.",
+      "unknown": "An unexpected error occurred."
     }
   },
   "entity": {

--- a/custom_components/jackery/translations/en.json
+++ b/custom_components/jackery/translations/en.json
@@ -21,7 +21,6 @@
     "error": {
       "invalid_auth": "Invalid email or password.",
       "cannot_connect": "Unable to connect to Jackery servers.",
-      "no_devices": "No devices found on this account.",
       "unknown": "An unexpected error occurred."
     },
     "abort": {

--- a/custom_components/jackery/translations/en.json
+++ b/custom_components/jackery/translations/en.json
@@ -29,6 +29,22 @@
       "reauth_successful": "Re-authentication successful."
     }
   },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Share Jackery Devices",
+        "description": "In the Jackery mobile app, select the device you want to share, open its settings, and tap \"Scan to share device(s)\" to scan the QR code below. The QR code expires in 5 minutes. After scanning, submit this form to reload the integration and pick up the newly shared devices.",
+        "data": {
+          "qr_code": "Scan with Jackery Mobile App"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "Unable to connect to Jackery servers.",
+      "qr_failed": "Failed to generate sharing QR code.",
+      "unknown": "An unexpected error occurred."
+    }
+  },
   "entity": {
     "sensor": {
       "battery": { "name": "Battery" },

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -122,20 +122,26 @@ CONF_PASSWORD = "password"
 
 ## Phase 2: Config flow [COMPLETE]
 
-**Why**: Entry point for users to add the integration. Validates credentials, discovers devices.
+**Why**: Entry point for users to add the integration. Validates credentials, discovers devices, handles device sharing via QR codes.
 
 ### File: `custom_components/jackery/config_flow.py`
 
 **Behavior**:
-1. Single step: prompt for email + password
+1. **User step**: prompt for email + password
 2. Call `await Client.login(email, password)` to validate credentials
-3. Call `await client.fetch_devices()` to verify at least one device exists
+3. Create config entry regardless of device count (allows empty accounts for sharing)
 4. Use `userId` from client credentials as unique ID (`async_set_unique_id` + `_abort_if_unique_id_configured`)
 5. Store `email` and `password` in `config_entry.data`
-6. Error mapping:
-   - `RuntimeError` from login → `invalid_auth`
-   - `aiohttp.ClientError` / `TimeoutError` → `cannot_connect`
-   - Empty device list → `no_devices`
+6. **Options Flow** (`JackeryOptionsFlow`):
+   - Accessible via integration gear icon → Configure
+   - `async_step_init` redirects directly to QR sharing
+   - `async_step_share_qr`: Generate QR code via `client.generate_share_qrcode()`
+   - Display QR code using `QrCodeSelector` with multiline instructions using `TextSelector`
+   - On form submit, reload entire integration to pick up newly shared devices
+7. Error mapping:
+   - `AuthenticationError` from login → `invalid_auth`
+   - `aiohttp.ClientError` / `TimeoutError` / `OSError` → `cannot_connect`
+   - QR generation failure → `qr_failed`
    - Other exceptions → `unknown`
 
 ### File: `custom_components/jackery/__init__.py` (stub)
@@ -143,10 +149,13 @@ CONF_PASSWORD = "password"
 Minimal `async_setup_entry` / `async_unload_entry` that just returns True. Will be fully implemented in Phase 3.
 
 ### Tests: `tests/test_config_flow.py`
-- Test successful login + device discovery → creates entry
+- Test successful login with/without devices → creates entry
 - Test invalid credentials → shows `invalid_auth` error
 - Test network error → shows `cannot_connect` error
-- Test no devices → shows `no_devices` error
+- Test Options Flow QR code generation and display
+- Test QR generation failures → shows `qr_failed` error
+- Test integration reload after QR sharing submission
+- Test network/auth errors during QR flow
 - Test duplicate account → aborts with `already_configured`
 
 ### Acceptance criteria

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
 ]
 requires-python = ">=3.12"
 dependencies = [
-    "socketry>=0.2.2",
+    "socketry>=0.2.4",
 ]
 
 [dependency-groups]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,6 +24,12 @@ class _StubConfigEntry:
     def __class_getitem__(cls, item: Any) -> type:
         return cls
 
+    def async_on_unload(self, func: Any) -> None:
+        pass
+
+    def add_update_listener(self, listener: Any) -> Any:
+        return lambda: None
+
 
 class _StubConfigFlow:
     """Minimal ConfigFlow stub that supports ``domain=`` class keyword."""
@@ -59,6 +65,28 @@ class _StubConfigFlow:
         """Update entry data and signal reauth success (test stub)."""
         entry.data = data
         return {"type": "abort", "reason": "reauth_successful"}
+
+
+class _StubOptionsFlow:
+    """Minimal OptionsFlow stub."""
+
+    hass: Any = None
+    config_entry: Any = None
+
+    def async_show_form(
+        self, *, step_id: str, data_schema: Any = None, errors: dict[str, str] | None = None,
+        description_placeholders: dict[str, str] | None = None,
+    ) -> dict[str, Any]:
+        return {
+            "type": "form",
+            "step_id": step_id,
+            "data_schema": data_schema,
+            "errors": errors or {},
+            "description_placeholders": description_placeholders or {},
+        }
+
+    def async_create_entry(self, *, title: str, data: dict[str, Any]) -> dict[str, Any]:
+        return {"type": "create_entry", "title": title, "data": data}
 
 
 # A simple alias for ConfigFlowResult
@@ -387,6 +415,7 @@ def _make_ha_modules() -> None:
     # homeassistant.core
     ha_core = ModuleType("homeassistant.core")
     ha_core.HomeAssistant = type("HomeAssistant", (), {})  # type: ignore[attr-defined]
+    ha_core.callback = lambda fn: fn  # type: ignore[attr-defined]  # passthrough decorator
     sys.modules["homeassistant.core"] = ha_core
 
     # homeassistant.const
@@ -406,6 +435,7 @@ def _make_ha_modules() -> None:
     ha_ce.ConfigEntry = _StubConfigEntry  # type: ignore[attr-defined]
     ha_ce.ConfigFlow = _StubConfigFlow  # type: ignore[attr-defined]
     ha_ce.ConfigFlowResult = ConfigFlowResult  # type: ignore[attr-defined]
+    ha_ce.OptionsFlow = _StubOptionsFlow  # type: ignore[attr-defined]
     sys.modules["homeassistant.config_entries"] = ha_ce
 
     # homeassistant.exceptions
@@ -477,6 +507,18 @@ def _make_ha_modules() -> None:
     ha_number.NumberEntityDescription = _NumberEntityDescription  # type: ignore[attr-defined]
     ha_number.NumberEntity = _NumberEntity  # type: ignore[attr-defined]
     sys.modules["homeassistant.components.number"] = ha_number
+
+    # homeassistant.helpers.selector
+    ha_selector = ModuleType("homeassistant.helpers.selector")
+    ha_selector.QrCodeSelector = lambda data: data  # type: ignore[attr-defined]
+    ha_selector.TextSelector = lambda config=None: config  # type: ignore[attr-defined]
+    ha_selector.TextSelectorConfig = lambda **kwargs: kwargs  # type: ignore[attr-defined]
+
+    class _TextSelectorType:  # noqa: N801
+        TEXT = "text"
+
+    ha_selector.TextSelectorType = _TextSelectorType  # type: ignore[attr-defined]
+    sys.modules["homeassistant.helpers.selector"] = ha_selector
 
 
 _make_ha_modules()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -74,7 +74,11 @@ class _StubOptionsFlow:
     config_entry: Any = None
 
     def async_show_form(
-        self, *, step_id: str, data_schema: Any = None, errors: dict[str, str] | None = None,
+        self,
+        *,
+        step_id: str,
+        data_schema: Any = None,
+        errors: dict[str, str] | None = None,
         description_placeholders: dict[str, str] | None = None,
     ) -> dict[str, Any]:
         return {

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -369,6 +369,42 @@ async def test_reauth_confirm_authentication_error(hass, existing_entry):
     assert result["errors"]["base"] == "invalid_auth"
 
 
+async def test_options_flow_network_error(hass, mock_client, mock_options_entry):
+    """Test options flow network error shows cannot_connect."""
+    mock_client.generate_share_qrcode = AsyncMock(side_effect=aiohttp.ClientError())
+
+    options_flow = _make_options_flow(hass, mock_options_entry)
+    result = await options_flow.async_step_init()
+
+    assert result["type"] == "form"
+    assert result["errors"]["base"] == "cannot_connect"
+
+
+async def test_options_flow_no_client(hass):
+    """Test options flow when client is None shows cannot_connect."""
+    mock_entry = MagicMock()
+    mock_entry.runtime_data = MagicMock()
+    mock_entry.runtime_data.client = None
+    mock_entry.entry_id = "test_entry_id"
+
+    options_flow = _make_options_flow(hass, mock_entry)
+    result = await options_flow.async_step_init()
+
+    assert result["type"] == "form"
+    assert result["errors"]["base"] == "cannot_connect"
+
+
+async def test_options_flow_auth_error(hass, mock_client, mock_options_entry):
+    """Test options flow raises ConfigEntryAuthFailed on auth error."""
+    from homeassistant.exceptions import ConfigEntryAuthFailed
+
+    mock_client.generate_share_qrcode = AsyncMock(side_effect=AuthenticationError("expired"))
+
+    options_flow = _make_options_flow(hass, mock_options_entry)
+    with pytest.raises(ConfigEntryAuthFailed):
+        await options_flow.async_step_init()
+
+
 async def test_reauth_confirm_cannot_connect(hass, existing_entry):
     """Network error during reauth shows cannot_connect error."""
     flow = _make_reauth_flow(hass, existing_entry)

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import aiohttp
 import pytest
-from socketry import AuthenticationError
+from socketry import AuthenticationError, SocketryError
 
 from custom_components.jackery.config_flow import JackeryConfigFlow
 from custom_components.jackery.const import CONF_EMAIL, CONF_PASSWORD
@@ -142,8 +143,8 @@ async def test_cannot_connect_os_error(hass):
     assert result["errors"]["base"] == "cannot_connect"
 
 
-async def test_no_devices(hass, mock_client):
-    """Test empty device list shows no_devices error."""
+async def test_no_devices_creates_entry(hass, mock_client):
+    """Test empty device list still creates config entry."""
     flow = _make_flow(hass)
     mock_client.devices = []
 
@@ -153,8 +154,10 @@ async def test_no_devices(hass, mock_client):
     ):
         result = await flow.async_step_user(user_input=VALID_INPUT)
 
-    assert result["type"] == "form"
-    assert result["errors"]["base"] == "no_devices"
+    assert result["type"] == "create_entry"
+    assert result["title"] == "user@example.com"
+    assert result["data"][CONF_EMAIL] == "user@example.com"
+    assert result["data"][CONF_PASSWORD] == "secret123"
 
 
 async def test_unknown_error(hass):
@@ -193,6 +196,79 @@ async def test_duplicate_account(hass, mock_client):
         pytest.raises(AbortFlow, match="already_configured"),
     ):
         await flow.async_step_user(user_input=VALID_INPUT)
+
+
+# --- Options Flow tests ---
+
+
+def _make_options_flow(hass: MagicMock, mock_entry: MagicMock) -> Any:
+    """Create a JackeryOptionsFlow with mocked entry and hass."""
+    from custom_components.jackery.config_flow import JackeryOptionsFlow
+
+    options_flow = JackeryOptionsFlow()
+    options_flow.hass = hass
+    options_flow.config_entry = mock_entry
+    return options_flow
+
+
+@pytest.fixture
+def mock_options_entry(mock_client):
+    """Create a mock config entry for options flow tests."""
+    mock_entry = MagicMock()
+    mock_entry.runtime_data = MagicMock()
+    mock_entry.runtime_data.client = mock_client
+    mock_entry.entry_id = "test_entry_id"
+    return mock_entry
+
+
+async def test_options_flow_available(hass, mock_options_entry):
+    """Test that options flow is available."""
+    from custom_components.jackery.config_flow import JackeryConfigFlow
+
+    options_flow = JackeryConfigFlow.async_get_options_flow(mock_options_entry)
+
+    assert options_flow is not None
+    assert hasattr(options_flow, "async_step_init")
+
+
+async def test_options_flow_shows_qr(hass, mock_client, mock_options_entry):
+    """Test options flow generates and displays QR code."""
+    mock_client.generate_share_qrcode = AsyncMock(
+        return_value={"qrCodeId": "abc123", "userId": 1234567890}
+    )
+
+    options_flow = _make_options_flow(hass, mock_options_entry)
+    result = await options_flow.async_step_init()
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "init"
+    assert "qr_code" in result["data_schema"].schema
+    mock_client.generate_share_qrcode.assert_awaited_once()
+
+
+async def test_options_flow_qr_generation_failure(hass, mock_client, mock_options_entry):
+    """Test options flow QR generation failure shows error."""
+    mock_client.generate_share_qrcode = AsyncMock(side_effect=SocketryError("QR generation failed"))
+
+    options_flow = _make_options_flow(hass, mock_options_entry)
+    result = await options_flow.async_step_init()
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "init"
+    assert result["errors"]["base"] == "qr_failed"
+
+
+async def test_options_flow_submit_creates_entry(hass, mock_client, mock_options_entry):
+    """Test options flow submit reloads integration and creates entry."""
+    hass.config_entries.async_reload = AsyncMock()
+    options_flow = _make_options_flow(hass, mock_options_entry)
+
+    result = await options_flow.async_step_init(user_input={"qr_code": ""})
+
+    assert result["type"] == "create_entry"
+    assert result["title"] == ""
+    assert result["data"] == {}
+    hass.config_entries.async_reload.assert_awaited_once_with("test_entry_id")
 
 
 # --- Reauth flow helpers ---

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -18,8 +18,8 @@ def test_manifest_required_fields():
     assert manifest["config_flow"] is True
     assert manifest["integration_type"] == "hub"
     assert manifest["iot_class"] == "cloud_push"
-    assert "socketry>=0.2.2" in manifest["requirements"]
-    assert manifest["version"] == "0.1.0"
+    assert "socketry>=0.2.3" in manifest["requirements"]
+    assert manifest["version"] == "0.2.1"
     assert "@jlopez" in manifest["codeowners"]
 
 
@@ -44,9 +44,25 @@ def test_strings_config_flow_coverage():
     errors = config["error"]
     assert "invalid_auth" in errors
     assert "cannot_connect" in errors
-    assert "no_devices" in errors
     assert "unknown" in errors
 
     # Abort definitions
     abort = config["abort"]
     assert "already_configured" in abort
+
+
+def test_strings_options_flow_coverage():
+    strings_path = INTEGRATION_DIR / "strings.json"
+    strings = json.loads(strings_path.read_text())
+    options = strings["options"]
+
+    # Step definitions
+    init_step = options["step"]["init"]
+    assert "title" in init_step
+    assert "description" in init_step
+    assert "qr_code" in init_step["data"]
+
+    # Error definitions
+    errors = options["error"]
+    assert "cannot_connect" in errors
+    assert "qr_failed" in errors

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -18,7 +18,7 @@ def test_manifest_required_fields():
     assert manifest["config_flow"] is True
     assert manifest["integration_type"] == "hub"
     assert manifest["iot_class"] == "cloud_push"
-    assert "socketry>=0.2.3" in manifest["requirements"]
+    assert "socketry>=0.2.4" in manifest["requirements"]
     assert manifest["version"] == "0.2.1"
     assert "@jlopez" in manifest["codeowners"]
 

--- a/uv.lock
+++ b/uv.lock
@@ -128,15 +128,6 @@ wheels = [
 ]
 
 [[package]]
-name = "annotated-doc"
-version = "0.0.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
-]
-
-[[package]]
 name = "attrs"
 version = "25.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -152,18 +143,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/4e/b5/721b8799b04bf9afe054a3899c6cf4e880fcf8563cc71c15610242490a0c/cfgv-3.5.0.tar.gz", hash = "sha256:d5b1034354820651caa73ede66a6294d6e95c1b00acc5e9b098e917404669132", size = 7334, upload-time = "2025-11-19T20:55:51.612Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl", hash = "sha256:a8dc6b26ad22ff227d2634a65cb388215ce6cc96bbcc5cfde7641ae87e8dacc0", size = 7445, upload-time = "2025-11-19T20:55:50.744Z" },
-]
-
-[[package]]
-name = "click"
-version = "8.3.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
 ]
 
 [[package]]
@@ -413,7 +392,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "socketry", specifier = ">=0.2.2" }]
+requires-dist = [{ name = "socketry", specifier = ">=0.2.4" }]
 
 [package.metadata.requires-dev]
 dev = [
@@ -484,27 +463,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b9/eb/7697f60fbe7042ab4e88f4ee6af496b7f222fffb0a4e3593ef1f29f81652/librt-0.8.1-cp314-cp314t-win32.whl", hash = "sha256:738f08021b3142c2918c03692608baed43bc51144c29e35807682f8070ee2a3a", size = 51328, upload-time = "2026-02-17T16:12:45.148Z" },
     { url = "https://files.pythonhosted.org/packages/7c/72/34bf2eb7a15414a23e5e70ecb9440c1d3179f393d9349338a91e2781c0fb/librt-0.8.1-cp314-cp314t-win_amd64.whl", hash = "sha256:89815a22daf9c51884fb5dbe4f1ef65ee6a146e0b6a8df05f753e2e4a9359bf4", size = 58722, upload-time = "2026-02-17T16:12:46.85Z" },
     { url = "https://files.pythonhosted.org/packages/b2/c8/d148e041732d631fc76036f8b30fae4e77b027a1e95b7a84bb522481a940/librt-0.8.1-cp314-cp314t-win_arm64.whl", hash = "sha256:bf512a71a23504ed08103a13c941f763db13fb11177beb3d9244c98c29fb4a61", size = 48755, upload-time = "2026-02-17T16:12:47.943Z" },
-]
-
-[[package]]
-name = "markdown-it-py"
-version = "4.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "mdurl" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
-]
-
-[[package]]
-name = "mdurl"
-version = "0.1.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
 ]
 
 [[package]]
@@ -979,19 +937,6 @@ wheels = [
 ]
 
 [[package]]
-name = "rich"
-version = "14.3.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "markdown-it-py" },
-    { name = "pygments" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b3/c6/f3b320c27991c46f43ee9d856302c70dc2d0fb2dba4842ff739d5f46b393/rich-14.3.3.tar.gz", hash = "sha256:b8daa0b9e4eef54dd8cf7c86c03713f53241884e814f4e2f5fb342fe520f639b", size = 230582, upload-time = "2026-02-19T17:23:12.474Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/14/25/b208c5683343959b670dc001595f2f3737e051da617f66c31f7c4fa93abc/rich-14.3.3-py3-none-any.whl", hash = "sha256:793431c1f8619afa7d3b52b2cdec859562b950ea0d4b6b505397612db8d5362d", size = 310458, upload-time = "2026-02-19T17:23:13.732Z" },
-]
-
-[[package]]
 name = "ruff"
 version = "0.15.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1017,42 +962,17 @@ wheels = [
 ]
 
 [[package]]
-name = "shellingham"
-version = "1.5.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
-]
-
-[[package]]
 name = "socketry"
-version = "0.2.2"
+version = "0.2.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
     { name = "aiomqtt" },
     { name = "pycryptodome" },
-    { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/86/e0/10808835a80cd532ead491a5cfd8481ef4a506de4a88679b4d82aa461d9f/socketry-0.2.2.tar.gz", hash = "sha256:0d3db83e8ec7929c36d916a9aa6b962c0c15aaad2a35a68c246b36b9ba0671b4", size = 21185, upload-time = "2026-03-02T18:45:32.771Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c8/05/235bc0a5833056f1f81d96735eeca7e4edfdf4178833e9b4695129589522/socketry-0.2.4.tar.gz", hash = "sha256:8cf2398c69ce5e8b2062530f5952bcc342eb2e237d9f67b19e5304d379429cd1", size = 22154, upload-time = "2026-03-31T22:55:59.107Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/68/f1/bdd54596b0a9a910f15f78a807c4b754f446133c3a58338889155cd9ee1a/socketry-0.2.2-py3-none-any.whl", hash = "sha256:d1c91026cbcf67f018c6832f1a460e12ffaaa4d7f86c01580e876fe4d7112cc1", size = 23635, upload-time = "2026-03-02T18:45:31.301Z" },
-]
-
-[[package]]
-name = "typer"
-version = "0.24.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "annotated-doc" },
-    { name = "click" },
-    { name = "rich" },
-    { name = "shellingham" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f5/24/cb09efec5cc954f7f9b930bf8279447d24618bb6758d4f6adf2574c41780/typer-0.24.1.tar.gz", hash = "sha256:e39b4732d65fbdcde189ae76cf7cd48aeae72919dea1fdfc16593be016256b45", size = 118613, upload-time = "2026-02-21T16:54:40.609Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/4a/91/48db081e7a63bb37284f9fbcefda7c44c277b18b0e13fbc36ea2335b71e6/typer-0.24.1-py3-none-any.whl", hash = "sha256:112c1f0ce578bfb4cab9ffdabc68f031416ebcc216536611ba21f04e9aa84c9e", size = 56085, upload-time = "2026-02-21T16:54:41.616Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/1b/b0ecfb12f6b7482199cecefcced9037e6e83e6a49800131e6115760acd33/socketry-0.2.4-py3-none-any.whl", hash = "sha256:fef279029fe95e7ee6c7912e7b74df241720c6088fb136427e362d323182ec7b", size = 24491, upload-time = "2026-03-31T22:55:57.98Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add QR code device sharing support through the integration's options flow, allowing users to share device access by scanning a QR code
- Require socketry>=0.2.4 which includes the QR code sharing API support

## Test plan
- [ ] Verify options flow presents QR code sharing option for configured devices
- [ ] Verify socketry 0.2.4 installs correctly from PyPI (no local dependency needed)
- [ ] Run `uv run pytest` — all tests pass
- [ ] Run `uv run mypy .` — no type errors
- [ ] Run `uv run ruff check .` — no lint issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)