### PR TITLE
fix: wait for device confirmation on switch/select/number commands

### DIFF
--- a/custom_components/jackery/number.py
+++ b/custom_components/jackery/number.py
@@ -93,7 +93,6 @@ class JackeryNumberEntity(JackeryEntity, NumberEntity):  # type: ignore[misc]
         coordinator = self.coordinator
         sn = self._device_sn
         slug = self.entity_description.slug
-        prop_key = self.entity_description.property_key
 
         if coordinator.client is None:
             return
@@ -101,14 +100,22 @@ class JackeryNumberEntity(JackeryEntity, NumberEntity):  # type: ignore[misc]
         int_value = int(value)
         try:
             device = coordinator.client.device(sn)
-            await device.set_property(slug, int_value)
+            response = await device.set_property(slug, int_value, wait=True)
         except (KeyError, ValueError, MqttError) as err:
             _LOGGER.error("Failed to set %s=%s for device %s: %s", slug, int_value, sn, err)
             return
 
-        # Optimistic update: immediately reflect the expected state
+        if response is None:
+            _LOGGER.warning(
+                "Device %s did not confirm %s=%s within timeout; state unchanged",
+                sn,
+                slug,
+                int_value,
+            )
+            return
+
         if coordinator.data is not None and sn in coordinator.data:
-            coordinator.data[sn][prop_key] = int_value
+            coordinator.data[sn].update(response)
             coordinator.async_set_updated_data(coordinator.data)
 
 

--- a/custom_components/jackery/select.py
+++ b/custom_components/jackery/select.py
@@ -88,25 +88,29 @@ class JackerySelectEntity(JackeryEntity, SelectEntity):  # type: ignore[misc]
         coordinator = self.coordinator
         sn = self._device_sn
         slug = self.entity_description.slug
-        prop_key = self.entity_description.property_key
 
         if coordinator.client is None:
             return
 
         try:
             device = coordinator.client.device(sn)
-            await device.set_property(slug, option)
+            response = await device.set_property(slug, option, wait=True)
         except (KeyError, ValueError, MqttError) as err:
             _LOGGER.error("Failed to set %s=%s for device %s: %s", slug, option, sn, err)
             return
 
-        # Optimistic update: map option string back to index
-        options = self.entity_description.options
-        if options is not None and option in options:
-            optimistic_value = options.index(option)
-            if coordinator.data is not None and sn in coordinator.data:
-                coordinator.data[sn][prop_key] = optimistic_value
-                coordinator.async_set_updated_data(coordinator.data)
+        if response is None:
+            _LOGGER.warning(
+                "Device %s did not confirm %s=%s within timeout; state unchanged",
+                sn,
+                slug,
+                option,
+            )
+            return
+
+        if coordinator.data is not None and sn in coordinator.data:
+            coordinator.data[sn].update(response)
+            coordinator.async_set_updated_data(coordinator.data)
 
 
 async def async_setup_entry(

--- a/custom_components/jackery/switch.py
+++ b/custom_components/jackery/switch.py
@@ -118,32 +118,39 @@ class JackerySwitchEntity(JackeryEntity, SwitchEntity):  # type: ignore[misc]
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
-        await self._async_set_state("on", 1)
+        await self._async_set_state("on")
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off."""
-        await self._async_set_state("off", 0)
+        await self._async_set_state("off")
 
-    async def _async_set_state(self, value: str, optimistic_value: int) -> None:
-        """Send a command to the device and apply an optimistic update."""
+    async def _async_set_state(self, value: str) -> None:
+        """Send a command and apply the device's echoed state."""
         coordinator = self.coordinator
         sn = self._device_sn
         slug = self.entity_description.slug
-        prop_key = self.entity_description.property_key
 
         if coordinator.client is None:
             return
 
         try:
             device = coordinator.client.device(sn)
-            await device.set_property(slug, value)
+            response = await device.set_property(slug, value, wait=True)
         except (KeyError, ValueError, MqttError) as err:
             _LOGGER.error("Failed to set %s=%s for device %s: %s", slug, value, sn, err)
             return
 
-        # Optimistic update: immediately reflect the expected state
+        if response is None:
+            _LOGGER.warning(
+                "Device %s did not confirm %s=%s within timeout; state unchanged",
+                sn,
+                slug,
+                value,
+            )
+            return
+
         if coordinator.data is not None and sn in coordinator.data:
-            coordinator.data[sn][prop_key] = optimistic_value
+            coordinator.data[sn].update(response)
             coordinator.async_set_updated_data(coordinator.data)
 
 

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -48,7 +48,7 @@ def _make_coordinator(
         coordinator.data = {sn: dict(props) for sn, props in FAKE_DATA.items()}
     coordinator.devices = devices if devices is not None else list(FAKE_DEVICES)
     coordinator.client = MagicMock()
-    coordinator.client.device.return_value.set_property = AsyncMock()
+    coordinator.client.device.return_value.set_property = AsyncMock(return_value={})
     return coordinator
 
 
@@ -205,7 +205,7 @@ async def test_set_value_calls_set_property_with_slug():
 
     client = _mock_client(coordinator)
     client.device.assert_called_once_with("SN001")
-    client.device.return_value.set_property.assert_called_once_with("auto-shutdown", 10)
+    client.device.return_value.set_property.assert_called_once_with("auto-shutdown", 10, wait=True)
 
 
 async def test_set_value_energy_saving():
@@ -215,7 +215,7 @@ async def test_set_value_energy_saving():
     await number.async_set_native_value(8.0)
 
     client = _mock_client(coordinator)
-    client.device.return_value.set_property.assert_called_once_with("energy-saving", 8)
+    client.device.return_value.set_property.assert_called_once_with("energy-saving", 8, wait=True)
 
 
 async def test_set_value_screen_timeout():
@@ -225,7 +225,9 @@ async def test_set_value_screen_timeout():
     await number.async_set_native_value(120.0)
 
     client = _mock_client(coordinator)
-    client.device.return_value.set_property.assert_called_once_with("screen-timeout", 120)
+    client.device.return_value.set_property.assert_called_once_with(
+        "screen-timeout", 120, wait=True
+    )
 
 
 async def test_set_value_routes_to_correct_device_sn():
@@ -236,24 +238,56 @@ async def test_set_value_routes_to_correct_device_sn():
 
     client = _mock_client(coordinator)
     client.device.assert_called_once_with("SN002")
-    client.device.return_value.set_property.assert_called_once_with("auto-shutdown", 5)
+    client.device.return_value.set_property.assert_called_once_with("auto-shutdown", 5, wait=True)
 
 
-async def test_set_value_applies_optimistic_update():
+async def test_set_value_applies_device_echo():
     coordinator = _make_coordinator()
     number = _make_number("ast", coordinator=coordinator)
+    client = _mock_client(coordinator)
+    client.device.return_value.set_property.return_value = {"ast": 18}
 
     # ast starts at 12
     assert number.native_value == 12.0
 
     await number.async_set_native_value(18.0)
 
-    # After set, optimistic update should set ast to 18
+    # State reflects what device echoed back
     assert coordinator.data["SN001"]["ast"] == 18
     assert number.native_value == 18.0
 
 
-async def test_set_value_logs_error_and_skips_optimistic_on_mqtt_error():
+async def test_set_value_reflects_device_clamping_via_echo():
+    """Device may clamp a value to its valid range; HA must reflect the clamped value."""
+    coordinator = _make_coordinator()
+    number = _make_number("ast", coordinator=coordinator)
+    client = _mock_client(coordinator)
+    # Commanded 50 but device clamped to 24
+    client.device.return_value.set_property.return_value = {"ast": 24}
+
+    await number.async_set_native_value(50.0)
+
+    # State reflects the clamped value, not the commanded value
+    assert coordinator.data["SN001"]["ast"] == 24
+    assert number.native_value == 24.0
+
+
+async def test_set_value_skips_state_update_on_timeout():
+    coordinator = _make_coordinator()
+    number = _make_number("ast", coordinator=coordinator)
+    client = _mock_client(coordinator)
+    client.device.return_value.set_property.return_value = None
+
+    assert number.native_value == 12.0
+
+    await number.async_set_native_value(18.0)
+
+    # No phantom state — original value preserved
+    assert coordinator.data["SN001"]["ast"] == 12
+    assert number.native_value == 12.0
+
+
+async def test_set_value_logs_error_and_skips_state_update_on_mqtt_error():
     coordinator = _make_coordinator()
     number = _make_number("ast", coordinator=coordinator)
 
@@ -265,7 +299,7 @@ async def test_set_value_logs_error_and_skips_optimistic_on_mqtt_error():
 
     await number.async_set_native_value(18.0)
 
-    # Optimistic update should NOT have been applied
+    # State should NOT have been applied
     assert coordinator.data["SN001"]["ast"] == 12
     assert number.native_value == 12.0
 
@@ -279,7 +313,7 @@ async def test_set_value_handles_key_error():
 
     await number.async_set_native_value(18.0)
 
-    # Optimistic update should NOT have been applied
+    # State should NOT have been applied
     assert coordinator.data["SN001"]["ast"] == 12
 
 

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -48,7 +48,7 @@ def _make_coordinator(
         coordinator.data = {sn: dict(props) for sn, props in FAKE_DATA.items()}
     coordinator.devices = devices if devices is not None else list(FAKE_DEVICES)
     coordinator.client = MagicMock()
-    coordinator.client.device.return_value.set_property = AsyncMock()
+    coordinator.client.device.return_value.set_property = AsyncMock(return_value={})
     return coordinator
 
 
@@ -193,7 +193,7 @@ async def test_select_option_calls_set_property_with_slug():
 
     client = _mock_client(coordinator)
     client.device.assert_called_once_with("SN001")
-    client.device.return_value.set_property.assert_called_once_with("light", "high")
+    client.device.return_value.set_property.assert_called_once_with("light", "high", wait=True)
 
 
 async def test_select_option_routes_to_correct_device_sn():
@@ -204,19 +204,21 @@ async def test_select_option_routes_to_correct_device_sn():
 
     client = _mock_client(coordinator)
     client.device.assert_called_once_with("SN002")
-    client.device.return_value.set_property.assert_called_once_with("light", "sos")
+    client.device.return_value.set_property.assert_called_once_with("light", "sos", wait=True)
 
 
-async def test_select_option_applies_optimistic_update():
+async def test_select_option_applies_device_echo():
     coordinator = _make_coordinator()
     select = _make_select("lm", coordinator=coordinator)
+    client = _mock_client(coordinator)
+    client.device.return_value.set_property.return_value = {"lm": 2}
 
     # lm starts at 0 ("off")
     assert select.current_option == "off"
 
     await select.async_select_option("high")
 
-    # After select, optimistic update should set lm to 2 (index of "high")
+    # State reflects the device's echoed index
     assert coordinator.data["SN001"]["lm"] == 2
     assert select.current_option == "high"
 
@@ -224,28 +226,62 @@ async def test_select_option_applies_optimistic_update():
 async def test_select_option_charge_speed():
     coordinator = _make_coordinator()
     select = _make_select("cs", coordinator=coordinator)
+    client = _mock_client(coordinator)
+    client.device.return_value.set_property.return_value = {"cs": 0}
 
     await select.async_select_option("fast")
 
-    client = _mock_client(coordinator)
-    client.device.return_value.set_property.assert_called_once_with("charge-speed", "fast")
-    # Optimistic update: "fast" is index 0
+    client.device.return_value.set_property.assert_called_once_with(
+        "charge-speed", "fast", wait=True
+    )
     assert coordinator.data["SN001"]["cs"] == 0
 
 
 async def test_select_option_battery_protection():
     coordinator = _make_coordinator()
     select = _make_select("lps", coordinator=coordinator)
+    client = _mock_client(coordinator)
+    client.device.return_value.set_property.return_value = {"lps": 1}
 
     await select.async_select_option("eco")
 
-    client = _mock_client(coordinator)
-    client.device.return_value.set_property.assert_called_once_with("battery-protection", "eco")
-    # Optimistic update: "eco" is index 1
+    client.device.return_value.set_property.assert_called_once_with(
+        "battery-protection", "eco", wait=True
+    )
     assert coordinator.data["SN001"]["lps"] == 1
 
 
-async def test_select_option_logs_error_and_skips_optimistic_on_mqtt_error():
+async def test_select_option_reflects_device_refusal_via_echo():
+    """Device may echo a value different from the commanded option."""
+    coordinator = _make_coordinator()
+    select = _make_select("lps", coordinator=coordinator)
+    client = _mock_client(coordinator)
+    # Commanded "eco" (index 1) but device kept "full" (index 0)
+    client.device.return_value.set_property.return_value = {"lps": 0}
+
+    await select.async_select_option("eco")
+
+    # State remains "full" — what the device actually reports
+    assert coordinator.data["SN001"]["lps"] == 0
+    assert select.current_option == "full"
+
+
+async def test_select_option_skips_state_update_on_timeout():
+    coordinator = _make_coordinator()
+    select = _make_select("lm", coordinator=coordinator)
+    client = _mock_client(coordinator)
+    client.device.return_value.set_property.return_value = None
+
+    assert select.current_option == "off"
+
+    await select.async_select_option("high")
+
+    # No phantom state — original value preserved
+    assert coordinator.data["SN001"]["lm"] == 0
+    assert select.current_option == "off"
+
+
+async def test_select_option_logs_error_and_skips_state_update_on_mqtt_error():
     coordinator = _make_coordinator()
     select = _make_select("lm", coordinator=coordinator)
 
@@ -257,7 +293,7 @@ async def test_select_option_logs_error_and_skips_optimistic_on_mqtt_error():
 
     await select.async_select_option("high")
 
-    # Optimistic update should NOT have been applied
+    # State should NOT have been applied
     assert coordinator.data["SN001"]["lm"] == 0
     assert select.current_option == "off"
 
@@ -271,7 +307,7 @@ async def test_select_option_handles_key_error():
 
     await select.async_select_option("high")
 
-    # Optimistic update should NOT have been applied
+    # State should NOT have been applied
     assert coordinator.data["SN001"]["lm"] == 0
 
 

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -54,7 +54,7 @@ def _make_coordinator(
         coordinator.data = {sn: dict(props) for sn, props in FAKE_DATA.items()}
     coordinator.devices = devices if devices is not None else list(FAKE_DEVICES)
     coordinator.client = MagicMock()
-    coordinator.client.device.return_value.set_property = AsyncMock()
+    coordinator.client.device.return_value.set_property = AsyncMock(return_value={})
     return coordinator
 
 
@@ -194,7 +194,7 @@ async def test_turn_on_calls_set_property_with_slug():
 
     client = _mock_client(coordinator)
     client.device.assert_called_once_with("SN001")
-    client.device.return_value.set_property.assert_called_once_with("ac", "on")
+    client.device.return_value.set_property.assert_called_once_with("ac", "on", wait=True)
 
 
 async def test_turn_off_calls_set_property_with_slug():
@@ -205,7 +205,7 @@ async def test_turn_off_calls_set_property_with_slug():
 
     client = _mock_client(coordinator)
     client.device.assert_called_once_with("SN001")
-    client.device.return_value.set_property.assert_called_once_with("dc", "off")
+    client.device.return_value.set_property.assert_called_once_with("dc", "off", wait=True)
 
 
 async def test_turn_on_routes_to_correct_device_sn():
@@ -216,33 +216,69 @@ async def test_turn_on_routes_to_correct_device_sn():
 
     client = _mock_client(coordinator)
     client.device.assert_called_once_with("SN002")
-    client.device.return_value.set_property.assert_called_once_with("ac", "on")
+    client.device.return_value.set_property.assert_called_once_with("ac", "on", wait=True)
 
 
-async def test_turn_on_applies_optimistic_update():
+async def test_turn_on_applies_device_echo():
     coordinator = _make_coordinator()
     switch = _make_switch("odc", coordinator=coordinator)
+    client = _mock_client(coordinator)
+    client.device.return_value.set_property.return_value = {"odc": 1}
 
     # odc starts at 0
     assert switch.is_on is False
 
     await switch.async_turn_on()
 
-    # After turn_on, optimistic update should set odc to 1
+    # State reflects what device echoed back
     assert coordinator.data["SN001"]["odc"] == 1
 
 
-async def test_turn_off_applies_optimistic_update():
+async def test_turn_off_applies_device_echo():
     coordinator = _make_coordinator()
     switch = _make_switch("oac", coordinator=coordinator)
+    client = _mock_client(coordinator)
+    client.device.return_value.set_property.return_value = {"oac": 0}
 
     # oac starts at 1
     assert switch.is_on is True
 
     await switch.async_turn_off()
 
-    # After turn_off, optimistic update should set oac to 0
+    # State reflects what device echoed back
     assert coordinator.data["SN001"]["oac"] == 0
+
+
+async def test_turn_off_reflects_device_refusal_via_echo():
+    """Device may echo unchanged value (firmware refusal); HA must reflect reality."""
+    coordinator = _make_coordinator()
+    switch = _make_switch("oac", coordinator=coordinator)
+    client = _mock_client(coordinator)
+    # Device refuses the turn-off and echoes oac=1 (still on)
+    client.device.return_value.set_property.return_value = {"oac": 1}
+
+    assert switch.is_on is True
+
+    await switch.async_turn_off()
+
+    # State remains 1 (truthful reflection of device refusing the command)
+    assert coordinator.data["SN001"]["oac"] == 1
+    assert switch.is_on is True
+
+
+async def test_turn_off_skips_state_update_on_timeout():
+    """When device does not confirm within timeout, leave state untouched."""
+    coordinator = _make_coordinator()
+    switch = _make_switch("oac", coordinator=coordinator)
+    client = _mock_client(coordinator)
+    client.device.return_value.set_property.return_value = None
+
+    assert switch.is_on is True
+
+    await switch.async_turn_off()
+
+    # No phantom state — original value preserved
+    assert coordinator.data["SN001"]["oac"] == 1
 
 
 async def test_turn_on_config_switch():
@@ -252,15 +288,15 @@ async def test_turn_on_config_switch():
     # sfc starts at 1 (on) -- turn off then on
     await switch.async_turn_off()
     client = _mock_client(coordinator)
-    client.device.return_value.set_property.assert_called_with("sfc", "off")
+    client.device.return_value.set_property.assert_called_with("sfc", "off", wait=True)
 
     client.device.reset_mock()
-    client.device.return_value.set_property = AsyncMock()
+    client.device.return_value.set_property = AsyncMock(return_value={})
     await switch.async_turn_on()
-    client.device.return_value.set_property.assert_called_with("sfc", "on")
+    client.device.return_value.set_property.assert_called_with("sfc", "on", wait=True)
 
 
-async def test_turn_on_logs_error_and_skips_optimistic_on_mqtt_error():
+async def test_turn_on_logs_error_and_skips_state_update_on_mqtt_error():
     coordinator = _make_coordinator()
     switch = _make_switch("oac", coordinator=coordinator)
 
@@ -273,7 +309,7 @@ async def test_turn_on_logs_error_and_skips_optimistic_on_mqtt_error():
     # Should not raise
     await switch.async_turn_on()
 
-    # Optimistic update should NOT have been applied (still 1, not changed)
+    # State should NOT have been applied (still 1, not changed)
     assert coordinator.data["SN001"]["oac"] == 1
 
 
@@ -286,7 +322,7 @@ async def test_turn_on_handles_key_error():
 
     await switch.async_turn_on()
 
-    # Optimistic update should NOT have been applied
+    # State should NOT have been applied
     assert coordinator.data["SN001"]["oac"] == 1
 
 


### PR DESCRIPTION
## Summary

- Replaces fire-and-forget MQTT commands plus optimistic local state writes with `wait=True` plus a merge of the device's echoed property dict.
- When the device does not confirm within the socketry timeout, log a warning and leave coordinator data untouched.
- Applied to `switch.py`, `select.py`, and `number.py` — all three platforms shared the same defect.

## Why

Previously, if the device firmware refused a command (e.g. AC output turn-off while a load is attached), HA would record a phantom state change that was later silently corrected by an unrelated periodic `DevicePropertyChange` push — breaking automations that rely on the command actually taking effect (the original report involved a low-battery cutoff that drained the battery anyway because the inverter never disengaged).

The fix:
- `wait=True` blocks until the device echoes the change (or a 10s timeout).
- The echoed dict is merged into coordinator data, so HA reflects what the device actually did (which may differ from what was commanded — clamping, refusal, etc.).
- A `None` response (timeout) leaves state alone and emits a warning so users can build watchdog automations.

Fixes #24

## Test plan

- [x] `uv run ruff check . && uv run ruff format --check .`
- [x] `uv run mypy custom_components/jackery`
- [x] `uv run pytest tests/test_switch.py tests/test_select.py tests/test_number.py` — all 96 tests pass, 100% coverage on the three modules
- [x] Existing call-site assertions updated to include `wait=True`
- [x] New tests for: device echo merged into state, divergent echo (firmware refusal / clamping) reflected in HA, timeout (None response) leaves state untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)