### PR TITLE
ci: add workflow_dispatch to CI and Release Please workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ on:
       - 'pyproject.toml'
       - 'uv.lock'
       - '.github/workflows/ci.yml'
+  workflow_dispatch:
 
 jobs:
   lint:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -3,6 +3,7 @@ name: Release Please
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary
- Add `workflow_dispatch:` trigger to both `ci.yml` and `release-please.yml` so they can be manually re-run from the Actions UI (or via `gh workflow run`) as a fallback.

## Context
PR #26 merged on 2026-04-26 but produced **no `push` event for `refs/heads/main`** (verified via the repo events API and `gh api .../actions/runs?head_sha=660e3d1` which returned `total_count: 0`). As a result, neither CI nor Release Please ran on the merge commit, so no 0.3.1 release PR was opened despite the `fix:` commit. Repo state is otherwise healthy (Actions enabled, both workflows `active`, no branch protection, normal user merge) — this looks like a transient GitHub-side glitch.

Merging this PR will itself produce the push event that retriggers Release Please on `main`, picking up PR #26's `fix:` commit and opening the 0.3.1 release PR. The added `workflow_dispatch` triggers are a safety net so a manual rerun is possible if this happens again.

## Test plan
- [ ] After merge: confirm `Release Please` runs on `main` for the merge commit
- [ ] Confirm a `chore(main): release 0.3.1` PR is opened by release-please